### PR TITLE
feat: add ERC-1363 payable token standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ ERC/
 │   │   ├── ERC165/         # Standard Interface Detection
 │   │   ├── ERC1271/        # Standard Signature Validation
 │   │   ├── ERC3156/        # Flash Loans
+│   │   ├── ERC1363/        # Payable Token
 │   │   └── ...
 │   └── shared/             # Shared components and utilities
 │       ├── interfaces/     # Interface definitions
@@ -87,7 +88,7 @@ This repository aims to implement a comprehensive collection of ERC standards ac
 
 ### 🟣 Transfer & Accounting Standards
 - **ERC-3156**: Flash Loans ✅ *complete* - [View Implementation](src/standards/ERC3156/) - [Read Docs](src/standards/ERC3156/README.md)
-- **ERC-1363**: Payable Token 📋 *planned*
+- **ERC-1363**: Payable Token ✅ *complete* - [View Implementation](src/standards/ERC1363/) - [Read Docs](src/standards/ERC1363/README.md)
 - **ERC-3525**: Semi-Fungible Token Standard 📋 *planned*
 - **ERC-3589**: Proxy ERC20 ⏳ *in progress*
 

--- a/src/shared/interfaces/IERC1363.sol
+++ b/src/shared/interfaces/IERC1363.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "./IERC20.sol";
+import {IERC165} from "./IERC165.sol";
+
+/**
+ * @title IERC1363
+ * @dev Payable Token interface (EIP-1363)
+ * @notice See https://eips.ethereum.org/EIPS/eip-1363
+ */
+interface IERC1363 is IERC20, IERC165 {
+    function transferAndCall(address to, uint256 value) external returns (bool);
+    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);
+    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);
+    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);
+    function approveAndCall(address spender, uint256 value) external returns (bool);
+    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);
+}

--- a/src/shared/interfaces/IERC1363Receiver.sol
+++ b/src/shared/interfaces/IERC1363Receiver.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IERC1363Receiver
+ * @dev Interface for contracts that support ERC1363 transfer callbacks
+ */
+interface IERC1363Receiver {
+    /**
+     * @notice Handle the receipt of ERC1363 tokens
+     * @param operator The address that initiated transferAndCall/transferFromAndCall
+     * @param from The address tokens were transferred from
+     * @param value The amount transferred
+     * @param data Additional data with no specified format
+     * @return bytes4 selector for callback confirmation
+     */
+    function onTransferReceived(address operator, address from, uint256 value, bytes calldata data)
+        external
+        returns (bytes4);
+}

--- a/src/shared/interfaces/IERC1363Spender.sol
+++ b/src/shared/interfaces/IERC1363Spender.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IERC1363Spender
+ * @dev Interface for contracts that support ERC1363 approval callbacks
+ */
+interface IERC1363Spender {
+    /**
+     * @notice Handle ERC1363 approval callback
+     * @param owner The address that approved tokens
+     * @param value The approved amount
+     * @param data Additional data with no specified format
+     * @return bytes4 selector for callback confirmation
+     */
+    function onApprovalReceived(address owner, uint256 value, bytes calldata data) external returns (bytes4);
+}

--- a/src/standards/ERC1363/ERC1363.sol
+++ b/src/standards/ERC1363/ERC1363.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "../ERC20/ERC20.sol";
+import {IERC1363} from "../../shared/interfaces/IERC1363.sol";
+import {IERC1363Receiver} from "../../shared/interfaces/IERC1363Receiver.sol";
+import {IERC1363Spender} from "../../shared/interfaces/IERC1363Spender.sol";
+import {IERC165} from "../../shared/interfaces/IERC165.sol";
+
+/**
+ * @title ERC1363
+ * @dev Implementation of ERC-1363 Payable Token standard
+ * @notice Extends ERC20 with transfer/approve callbacks in a single transaction
+ * @custom:security-contact This contract should be audited before use in production
+ */
+contract ERC1363 is ERC20, IERC1363 {
+    bytes4 private constant _TRANSFER_RECEIVED = IERC1363Receiver.onTransferReceived.selector;
+    bytes4 private constant _APPROVAL_RECEIVED = IERC1363Spender.onApprovalReceived.selector;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, uint256 totalSupply_)
+        ERC20(name_, symbol_, decimals_, totalSupply_)
+    {}
+
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC1363).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    function transferAndCall(address to, uint256 value) public virtual override returns (bool) {
+        return transferAndCall(to, value, "");
+    }
+
+    function transferAndCall(address to, uint256 value, bytes memory data) public virtual override returns (bool) {
+        address owner = msg.sender;
+        _transfer(owner, to, value);
+        _checkAndCallTransferReceived(owner, owner, to, value, data);
+        return true;
+    }
+
+    function transferFromAndCall(address from, address to, uint256 value) public virtual override returns (bool) {
+        return transferFromAndCall(from, to, value, "");
+    }
+
+    function transferFromAndCall(address from, address to, uint256 value, bytes memory data)
+        public
+        virtual
+        override
+        returns (bool)
+    {
+        address spender = msg.sender;
+        _spendAllowance(from, spender, value);
+        _transfer(from, to, value);
+        _checkAndCallTransferReceived(spender, from, to, value, data);
+        return true;
+    }
+
+    function approveAndCall(address spender, uint256 value) public virtual override returns (bool) {
+        return approveAndCall(spender, value, "");
+    }
+
+    function approveAndCall(address spender, uint256 value, bytes memory data) public virtual override returns (bool) {
+        address owner = msg.sender;
+        _approve(owner, spender, value);
+        _checkAndCallApprovalReceived(owner, spender, value, data);
+        return true;
+    }
+
+    function _checkAndCallTransferReceived(address operator, address from, address to, uint256 value, bytes memory data)
+        internal
+    {
+        require(to.code.length > 0, "ERC1363: receiver is not contract");
+        bytes4 retval = IERC1363Receiver(to).onTransferReceived(operator, from, value, data);
+        require(retval == _TRANSFER_RECEIVED, "ERC1363: invalid receiver return");
+    }
+
+    function _checkAndCallApprovalReceived(address owner, address spender, uint256 value, bytes memory data) internal {
+        require(spender.code.length > 0, "ERC1363: spender is not contract");
+        bytes4 retval = IERC1363Spender(spender).onApprovalReceived(owner, value, data);
+        require(retval == _APPROVAL_RECEIVED, "ERC1363: invalid spender return");
+    }
+}

--- a/src/standards/ERC1363/ERC1363Testable.sol
+++ b/src/standards/ERC1363/ERC1363Testable.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC1363} from "./ERC1363.sol";
+
+/**
+ * @title ERC1363Testable
+ * @dev Testable version of ERC1363 with mint/burn helpers
+ * @notice DO NOT use in production - use ERC1363 instead
+ */
+contract ERC1363Testable is ERC1363 {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, uint256 totalSupply_)
+        ERC1363(name_, symbol_, decimals_, totalSupply_)
+    {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}

--- a/src/standards/ERC1363/README.md
+++ b/src/standards/ERC1363/README.md
@@ -1,0 +1,33 @@
+# ERC-1363 Payable Token
+
+## Overview
+
+Implementation of the [ERC-1363 Payable Token](https://eips.ethereum.org/EIPS/eip-1363), which extends ERC-20 with callback-enabled transfers and approvals.
+
+## Features
+
+- **transferAndCall**: Transfer tokens and execute receiver logic in one transaction
+- **transferFromAndCall**: Transfer on behalf of owner and invoke receiver callback
+- **approveAndCall**: Approve spender and invoke spender callback
+- **ERC-165 Detection**: Supports interface detection via `supportsInterface`
+
+## Contracts
+
+- `ERC1363.sol`: ERC1363 implementation extending `ERC20`
+- `ERC1363Testable.sol`: Testable version exposing mint and burn
+
+## Usage
+
+```solidity
+import {ERC1363} from "./ERC1363.sol";
+
+ERC1363 token = new ERC1363("Payable Token", "PAY", 18, 1_000_000e18);
+```
+
+Receiver contracts must implement `IERC1363Receiver` and spender contracts must implement `IERC1363Spender`.
+
+## Testing
+
+```bash
+forge test --match-path test/standards/ERC1363/ERC1363.t.sol
+```

--- a/test/standards/ERC1363/ERC1363.t.sol
+++ b/test/standards/ERC1363/ERC1363.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1363Testable} from "../../../src/standards/ERC1363/ERC1363Testable.sol";
+import {IERC1363Receiver} from "../../../src/shared/interfaces/IERC1363Receiver.sol";
+import {IERC1363Spender} from "../../../src/shared/interfaces/IERC1363Spender.sol";
+import {IERC1363} from "../../../src/shared/interfaces/IERC1363.sol";
+import {IERC165} from "../../../src/shared/interfaces/IERC165.sol";
+
+contract ERC1363ReceiverMock is IERC1363Receiver {
+    bytes4 public response;
+    address public operator;
+    address public from;
+    uint256 public value;
+    bytes public data;
+
+    constructor(bytes4 response_) {
+        response = response_;
+    }
+
+    function onTransferReceived(address operator_, address from_, uint256 value_, bytes calldata data_)
+        external
+        override
+        returns (bytes4)
+    {
+        operator = operator_;
+        from = from_;
+        value = value_;
+        data = data_;
+        return response;
+    }
+}
+
+contract ERC1363SpenderMock is IERC1363Spender {
+    bytes4 public response;
+    address public owner;
+    uint256 public value;
+    bytes public data;
+
+    constructor(bytes4 response_) {
+        response = response_;
+    }
+
+    function onApprovalReceived(address owner_, uint256 value_, bytes calldata data_)
+        external
+        override
+        returns (bytes4)
+    {
+        owner = owner_;
+        value = value_;
+        data = data_;
+        return response;
+    }
+}
+
+contract NonReceiver {}
+
+contract ERC1363Test is Test {
+    ERC1363Testable public token;
+
+    string constant NAME = "Payable Token";
+    string constant SYMBOL = "PAY";
+    uint8 constant DECIMALS = 18;
+    uint256 constant INITIAL_SUPPLY = 1_000_000e18;
+
+    address public owner = address(0x1);
+    address public user1 = address(0x2);
+
+    ERC1363ReceiverMock public receiver;
+    ERC1363ReceiverMock public badReceiver;
+    ERC1363SpenderMock public spender;
+    ERC1363SpenderMock public badSpender;
+    NonReceiver public eoaLike;
+
+    function setUp() public {
+        vm.prank(owner);
+        token = new ERC1363Testable(NAME, SYMBOL, DECIMALS, INITIAL_SUPPLY);
+
+        receiver = new ERC1363ReceiverMock(IERC1363Receiver.onTransferReceived.selector);
+        badReceiver = new ERC1363ReceiverMock(bytes4(0xdeadbeef));
+        spender = new ERC1363SpenderMock(IERC1363Spender.onApprovalReceived.selector);
+        badSpender = new ERC1363SpenderMock(bytes4(0xdeadbeef));
+        eoaLike = new NonReceiver();
+    }
+
+    function test_TransferAndCall_Success() public {
+        vm.prank(owner);
+        bool ok = token.transferAndCall(address(receiver), 100e18, bytes("hello"));
+
+        assertTrue(ok);
+        assertEq(token.balanceOf(address(receiver)), 100e18);
+        assertEq(receiver.operator(), owner);
+        assertEq(receiver.from(), owner);
+        assertEq(receiver.value(), 100e18);
+        assertEq(receiver.data(), bytes("hello"));
+    }
+
+    function test_TransferAndCall_RevertWhenReceiverNotContract() public {
+        vm.prank(owner);
+        vm.expectRevert("ERC1363: receiver is not contract");
+        token.transferAndCall(user1, 1e18);
+    }
+
+    function test_TransferAndCall_RevertWhenInvalidReceiverReturn() public {
+        vm.prank(owner);
+        vm.expectRevert("ERC1363: invalid receiver return");
+        token.transferAndCall(address(badReceiver), 1e18);
+    }
+
+    function test_TransferFromAndCall_Success() public {
+        vm.prank(owner);
+        token.approve(user1, 50e18);
+
+        vm.prank(user1);
+        bool ok = token.transferFromAndCall(owner, address(receiver), 50e18, bytes("x"));
+
+        assertTrue(ok);
+        assertEq(token.balanceOf(address(receiver)), 50e18);
+        assertEq(receiver.operator(), user1);
+        assertEq(receiver.from(), owner);
+    }
+
+    function test_ApproveAndCall_Success() public {
+        vm.prank(owner);
+        bool ok = token.approveAndCall(address(spender), 123e18, bytes("data"));
+
+        assertTrue(ok);
+        assertEq(token.allowance(owner, address(spender)), 123e18);
+        assertEq(spender.owner(), owner);
+        assertEq(spender.value(), 123e18);
+        assertEq(spender.data(), bytes("data"));
+    }
+
+    function test_ApproveAndCall_RevertWhenSpenderNotContract() public {
+        vm.prank(owner);
+        vm.expectRevert("ERC1363: spender is not contract");
+        token.approveAndCall(user1, 1e18);
+    }
+
+    function test_ApproveAndCall_RevertWhenInvalidSpenderReturn() public {
+        vm.prank(owner);
+        vm.expectRevert("ERC1363: invalid spender return");
+        token.approveAndCall(address(badSpender), 1e18);
+    }
+
+    function test_SupportsInterface_ERC1363() public view {
+        assertTrue(token.supportsInterface(type(IERC1363).interfaceId));
+    }
+
+    function test_SupportsInterface_ERC165() public view {
+        assertTrue(token.supportsInterface(type(IERC165).interfaceId));
+    }
+}


### PR DESCRIPTION
Implement ERC-1363 with transfer/approve callbacks, add receiver/spender interfaces, and include full test coverage and documentation following the existing repository structure.